### PR TITLE
feat: Update navigation links to external sites

### DIFF
--- a/src/components/NavHeader.vue
+++ b/src/components/NavHeader.vue
@@ -18,9 +18,9 @@
         </div>
       </div>
       <nav class="nav-menu">
-        <a href="#" class="nav-link">应用</a>
-        <a href="#" class="nav-link">工具</a>
-        <a href="#" class="nav-link">关于</a>
+        <a href="https://www.youtube.com/@laosji" target="_blank" class="nav-link">我的YouTube</a>
+        <a href="https://t.me/cjfuli/19" target="_blank" class="nav-link">订阅我的telegram频道</a>
+        <a href="https://laosji.net/" target="_blank" class="nav-link">关于</a>
       </nav>
     </div>
   </header>


### PR DESCRIPTION
Updates the navigation links in the header to point to the user's personal Telegram channel, YouTube channel, and blog.

- Changes '应用' to '我的YouTube' and links to the user's YouTube channel.
- Changes '工具' to '订阅我的telegram频道' and links to the user's Telegram channel.
- Changes '关于' to link to the user's blog.
- Adds target="_blank" to all links to ensure they open in a new tab.